### PR TITLE
Use a protocol-independent base URL for generating charts.

### DIFF
--- a/pygooglechart.py
+++ b/pygooglechart.py
@@ -295,7 +295,7 @@ class Chart(object):
     of the chart. legend requires a list that corresponds to datasets.
     """
 
-    BASE_URL = 'http://chart.apis.google.com/chart'
+    BASE_URL = '//www.google.com/chart'
     BACKGROUND = 'bg'
     CHART = 'c'
     ALPHA = 'a'


### PR DESCRIPTION
The server at www.google.com/chart has a proper SSL certificate, but chart.apis.google.com doesn't.
